### PR TITLE
Removed specific form name from download page

### DIFF
--- a/src/datoso_seed_nointro/fetch.py
+++ b/src/datoso_seed_nointro/fetch.py
@@ -98,7 +98,7 @@ def download_daily(folder_helper):
 
         print("Downloading")
         sleep_time()
-        download_button = driver.find_element(By.CSS_SELECTOR, "form[name='opt_form'] input[name='lazy_mode']")
+        download_button = driver.find_element(By.CSS_SELECTOR, "form input[name='lazy_mode']")
         download_button.click()
 
         while not is_download_finished(folder_helper):


### PR DESCRIPTION
No-Intro has updated the download page; the form element no longer has a `name` tag. This change allows the marionette to work with the page as it is live now.